### PR TITLE
Capture uglify-js build dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build/v.js: build/v.core.js src/macros.sjs src/v.js
 	cat src/macros.sjs src/v.js | node_modules/.bin/sjs -s -o build/v.js
 
 build/v.min.js: build/v.js lib/*.js
-	node_modules/.bin/browserify build/v.js | uglifyjs -c -m toplevel >build/v.min.js 2>/dev/null
+	node_modules/.bin/browserify build/v.js | node_modules/.bin/uglifyjs -c -m toplevel >build/v.min.js 2>/dev/null
 
 build/v.core.test.js: src/macros.sjs src/v.core.js test/v.core.js
 	cat src/macros.sjs src/v.core.js test/v.core.js | node_modules/.bin/sjs -s -o build/v.core.test.js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "sweet.js": "0.7.4",
     "browserify": "4.1.2",
     "d3": "3.5.3",
-    "virtual-dom": "0.0.24"
+    "virtual-dom": "0.0.24",
+    "uglify-js": "2.4.16"
   }
 }


### PR DESCRIPTION
I didn't have an `uglifyjs` in my `$PATH` and it was causing _everything_ to silently fail because `v.min.js` wound up being created as an empty file.
Capturing this build dependency fixes that issue.

Adding a `clean` target to the `Makefile` would also have helped with troubleshooting.
